### PR TITLE
Le Racisme

### DIFF
--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -19,8 +19,6 @@
 		/datum/species/human/gravworlder = list(HUMAN_ONLY_JOBS), //Not considered human enough for command roles.
 		/datum/species/human/tritonian = list(HUMAN_ONLY_JOBS),
 		/datum/species/human/vatgrown = list(HUMAN_ONLY_JOBS),
-		/datum/species/human/mule = list(HUMAN_ONLY_JOBS),
-		/datum/species/human/spacer = list(HUMAN_ONLY_JOBS),
 	)
 #undef HUMAN_ONLY_JOBS
 

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -16,9 +16,11 @@
 		/datum/species/skrell  = list(HUMAN_ONLY_JOBS),
 		/datum/species/machine = list(HUMAN_ONLY_JOBS),
 		/datum/species/diona   = list(HUMAN_ONLY_JOBS),
-		/datum/species/human/gravworlder = list(HUMAN_ONLY_JOBS), //Not considered human enough for command roles.
-	/datum/species/human/tritonian = list(HUMAN_ONLY_JOBS),
-	/datum/species/human/vatgrown = list(HUMAN_ONLY_JOBS),
+		/datum/species/human/gravworlder  = list(HUMAN_ONLY_JOBS),//Not considered human enough for command roles.
+		/datum/species/human/tritonian  = list(HUMAN_ONLY_JOBS),
+		/datum/species/human/vatgrown  = list(HUMAN_ONLY_JOBS),
+		/datum/species/human/spacer  = list(HUMAN_ONLY_JOBS),
+		/datum/species/human/mule  = list(HUMAN_ONLY_JOBS),
 	)
 #undef HUMAN_ONLY_JOBS
 

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -11,12 +11,12 @@
 
 #define HUMAN_ONLY_JOBS /datum/job/captain, /datum/job/hop, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/representative, /datum/job/sea, /datum/job/pathfinder, /datum/job/rd
 	species_to_job_blacklist = list(
-		/datum/species/unathi  = list(HUMAN_ONLY_JOBS), //Other jobs unavailable via branch restrictions,
+		/datum/species/unathi  = list(HUMAN_ONLY_JOBS),
 		/datum/species/unathi/yeosa = list(HUMAN_ONLY_JOBS),
 		/datum/species/skrell  = list(HUMAN_ONLY_JOBS),
 		/datum/species/machine = list(HUMAN_ONLY_JOBS),
-		/datum/species/diona   = list(HUMAN_ONLY_JOBS),	//Other jobs unavailable via branch restrictions,
-		/datum/species/human/gravworlder = list(HUMAN_ONLY_JOBS), //human subspecies aren't human enough for the funni command roles.
+		/datum/species/diona   = list(HUMAN_ONLY_JOBS),
+		/datum/species/human/gravworlder = list(HUMAN_ONLY_JOBS), //Not considered human enough for command roles.
 		/datum/species/human/spacer = list(HUMAN_ONLY_JOBS),
 		/datum/species/human/tritonian = list(HUMAN_ONLY_JOBS),
 		/datum/species/human/vatgrown = list(HUMAN_ONLY_JOBS),

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -17,8 +17,8 @@
 		/datum/species/machine = list(HUMAN_ONLY_JOBS),
 		/datum/species/diona   = list(HUMAN_ONLY_JOBS),
 		/datum/species/human/gravworlder = list(HUMAN_ONLY_JOBS), //Not considered human enough for command roles.
-		/datum/species/human/tritonian = list(HUMAN_ONLY_JOBS),
-		/datum/species/human/vatgrown = list(HUMAN_ONLY_JOBS),
+	/datum/species/human/tritonian = list(HUMAN_ONLY_JOBS),
+	/datum/species/human/vatgrown = list(HUMAN_ONLY_JOBS),
 	)
 #undef HUMAN_ONLY_JOBS
 

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -11,16 +11,16 @@
 
 #define HUMAN_ONLY_JOBS /datum/job/captain, /datum/job/hop, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/representative, /datum/job/sea, /datum/job/pathfinder, /datum/job/rd
 	species_to_job_blacklist = list(
-		/datum/species/unathi  = list(HUMAN_ONLY_JOBS),
+		/datum/species/unathi = list(HUMAN_ONLY_JOBS),
 		/datum/species/unathi/yeosa = list(HUMAN_ONLY_JOBS),
-		/datum/species/skrell  = list(HUMAN_ONLY_JOBS),
+		/datum/species/diona = list(HUMAN_ONLY_JOBS),
+		/datum/species/skrell = list(HUMAN_ONLY_JOBS),
 		/datum/species/machine = list(HUMAN_ONLY_JOBS),
-		/datum/species/diona   = list(HUMAN_ONLY_JOBS),
-		/datum/species/human/gravworlder  = list(HUMAN_ONLY_JOBS),//Not considered human enough for command roles.
-		/datum/species/human/tritonian  = list(HUMAN_ONLY_JOBS),
-		/datum/species/human/vatgrown  = list(HUMAN_ONLY_JOBS),
-		/datum/species/human/spacer  = list(HUMAN_ONLY_JOBS),
-		/datum/species/human/mule  = list(HUMAN_ONLY_JOBS),
+		/datum/species/human/gravworlder = list(HUMAN_ONLY_JOBS),
+		/datum/species/human/spacer = list(HUMAN_ONLY_JOBS),
+		/datum/species/human/tritonian = list(HUMAN_ONLY_JOBS),
+		/datum/species/human/vatgrown = list(HUMAN_ONLY_JOBS),
+		/datum/species/human/mule = list(HUMAN_ONLY_JOBS),
 	)
 #undef HUMAN_ONLY_JOBS
 

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -17,10 +17,10 @@
 		/datum/species/machine = list(HUMAN_ONLY_JOBS),
 		/datum/species/diona   = list(HUMAN_ONLY_JOBS),
 		/datum/species/human/gravworlder = list(HUMAN_ONLY_JOBS), //Not considered human enough for command roles.
-		/datum/species/human/spacer = list(HUMAN_ONLY_JOBS),
 		/datum/species/human/tritonian = list(HUMAN_ONLY_JOBS),
 		/datum/species/human/vatgrown = list(HUMAN_ONLY_JOBS),
 		/datum/species/human/mule = list(HUMAN_ONLY_JOBS),
+		/datum/species/human/spacer = list(HUMAN_ONLY_JOBS),
 	)
 #undef HUMAN_ONLY_JOBS
 

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -16,6 +16,11 @@
 		/datum/species/skrell  = list(HUMAN_ONLY_JOBS),
 		/datum/species/machine = list(HUMAN_ONLY_JOBS, /datum/job/liaison, /datum/job/psychiatrist, /datum/job/bridgeofficer, /datum/job/senior_engineer, /datum/job/warden, /datum/job/qm, /datum/job/senior_scientist),
 		/datum/species/diona   = list(HUMAN_ONLY_JOBS, /datum/job/officer, /datum/job/liaison, /datum/job/warden, /datum/job/doctor, /datum/job/medical_trainee),	//Other jobs unavailable via branch restrictions,
+		/datum/species/human/gravworlder = list(HUMAN_ONLY_JOBS), //human subspecies aren't human enough for the funni command roles.
+		/datum/species/human/spacer = list(HUMAN_ONLY_JOBS),
+		/datum/species/human/tritonian = list(HUMAN_ONLY_JOBS),
+		/datum/species/human/vatgrown = list(HUMAN_ONLY_JOBS),
+		/datum/species/human/mule = list(HUMAN_ONLY_JOBS),
 	)
 #undef HUMAN_ONLY_JOBS
 

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -11,11 +11,11 @@
 
 #define HUMAN_ONLY_JOBS /datum/job/captain, /datum/job/hop, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/representative, /datum/job/sea, /datum/job/pathfinder, /datum/job/rd
 	species_to_job_blacklist = list(
-		/datum/species/unathi  = list(HUMAN_ONLY_JOBS, /datum/job/liaison, /datum/job/warden), //Other jobs unavailable via branch restrictions,
-		/datum/species/unathi/yeosa = list(HUMAN_ONLY_JOBS, /datum/job/liaison, /datum/job/warden),
+		/datum/species/unathi  = list(HUMAN_ONLY_JOBS), //Other jobs unavailable via branch restrictions,
+		/datum/species/unathi/yeosa = list(HUMAN_ONLY_JOBS),
 		/datum/species/skrell  = list(HUMAN_ONLY_JOBS),
-		/datum/species/machine = list(HUMAN_ONLY_JOBS, /datum/job/liaison, /datum/job/psychiatrist, /datum/job/bridgeofficer, /datum/job/senior_engineer, /datum/job/warden, /datum/job/qm, /datum/job/senior_scientist),
-		/datum/species/diona   = list(HUMAN_ONLY_JOBS, /datum/job/officer, /datum/job/liaison, /datum/job/warden, /datum/job/doctor, /datum/job/medical_trainee),	//Other jobs unavailable via branch restrictions,
+		/datum/species/machine = list(HUMAN_ONLY_JOBS),
+		/datum/species/diona   = list(HUMAN_ONLY_JOBS),	//Other jobs unavailable via branch restrictions,
 		/datum/species/human/gravworlder = list(HUMAN_ONLY_JOBS), //human subspecies aren't human enough for the funni command roles.
 		/datum/species/human/spacer = list(HUMAN_ONLY_JOBS),
 		/datum/species/human/tritonian = list(HUMAN_ONLY_JOBS),


### PR DESCRIPTION
Adds sub-human species (mules, tritonians, grav-adapts, and space-adapts) to the command blacklist. They are treated the same as nonhumans in this regard, and are not eligible for any command roles.

Additionally, unrestricts a bunch of roles from aliens, excluding command roles. Restrictions may or may not return or be altered.